### PR TITLE
Use gaze 0.5.1 to support OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "aster-src": "^0.1.2",
-    "gaze": "^0.6.4",
+    "gaze": "^0.5.1",
     "rx": "^2.3.11"
   },
   "devDependencies": {


### PR DESCRIPTION
See shama/gaze#175 for detail. gaze 0.6.4 can't install on OSX node 0.11 and later.
